### PR TITLE
Stop IsolateHolderService when app is killed with swipe to remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,7 @@
 ## 0.1.2+1
 
 * Conform to dart formatting standards to improve pub.dev score
+
+## 0.1.3
+
+* Stop IsolateHolderService when app is killed with swipe to remove

--- a/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
+++ b/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
@@ -85,5 +85,10 @@ class IsolateHolderService : Service() {
             stopSelf()
         }
         return START_STICKY;
+    } 
+
+    override fun onTaskRemoved(rootIntent: Intent) {
+        super.onTaskRemoved(rootIntent);
+        stopSelf();
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_background
 description: A plugin to keep flutter apps running in the background by using foreground service, wake lock and disabling battery optimizations
-version: 0.1.2+1
+version: 0.1.3
 repository: https://github.com/JulianAssmann/flutter_background
 homepage: https://julianassmann.de/
 


### PR DESCRIPTION
Hello.
This package is great and I am using it well.
and I am appreciated your work.

I can stop IsolateHolderService with stop "FlutterBackground.disableBackgroundExecution()".
But when I kill app with swipe to remove action at recent apps, the service is still there.
I googled and found this solution.

This is my first time to create PR and I am not sure this is right way.
But I wish this will help you.

If you feel bad, please ignore this PR.



