### PR TITLE
Fix crash when calling FlutterPlugin.[initialize, hasPermissions] for the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,14 @@
 * Add analysis_options.yaml based on pedantic v. 1.9.0 for static analysis and conform to it
 * Update example app and server
 
-## 0.1.2+1
-
-* Conform to dart formatting standards to improve pub.dev score
-
 ## 0.1.3
 
 * Stop IsolateHolderService when app is killed with swipe to remove
+
+## 0.1.4
+
+* Fix bug where calling `FlutterBackground.initialize()` for the first time crashes the app
+* Fix bug where calling `FlutterBackground.hasPermissions` for the first time crashes the app
+* Fix some typos
+* Address notification icon in the documentation
+* Enhance error handling in example app

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A plugin to keep flutter apps running in the background. Currently only works with Android.
 
-It achives this functionality by running an [Android foreground service](https://developer.android.com/guide/components/foreground-services) in combination with a [partial wake lock](https://developer.android.com/training/scheduling/wakelock#cpu) and [disabling battery optimizations](https://developer.android.com/training/monitoring-device-state/doze-standby#support_for_other_use_cases) in order to keep the flutter isolate running.
+It achieves this functionality by running an [Android foreground service](https://developer.android.com/guide/components/foreground-services) in combination with a [partial wake lock](https://developer.android.com/training/scheduling/wakelock#cpu) and [disabling battery optimizations](https://developer.android.com/training/monitoring-device-state/doze-standby#support_for_other_use_cases) in order to keep the flutter isolate running.
 
 **Note:** This plugin currently only works with Android.
 PRs for iOS are very welcome, although I am not sure if a similiar effect can be achieved with iOS at all.
@@ -82,6 +82,11 @@ await FlutterBackground.disbleBackgroundExecution();
 
 you can stop the background execution of the app. You must call `FlutterBackground.initialize()` before calling `FlutterBackground.disbleBackgroundExecution()`.
 
+### Notes
+
+The plugin is currently hard-coded to load the icon for the foreground service notification from a drawable resource with the identifier `ic_launcher`. 
+So if you want to change the logo for the notification, you have to change this resource. I'm planning to allow for custom resource names.
+
 ## Example
 
 The example is a TCP chat app: It can connect to a TCP server and send and receive messages. The user is notified about incoming messages by notifications created with the plugin [flutter_local_notifications](https://pub.dev/packages/flutter_local_notifications).
@@ -92,11 +97,12 @@ Using this plugin, the example app can maintain the TCP connection with the serv
 
 - Add automated tests
 - On android, add [ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS](https://developer.android.com/reference/android/provider/Settings#ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS) as an option to obtain excemption from battery optimizations, as declaring [REQUEST_IGNORE_BATTERY_OPTIMIZATIONS](https://developer.android.com/reference/android/Manifest.permission.html#REQUEST_IGNORE_BATTERY_OPTIMIZATIONS) might lead to a ban of the app in the Play Store, "unless the core function of the app is adversely affected" (see the note [here](https://developer.android.com/training/monitoring-device-state/doze-standby.html#support_for_other_use_cases))
+- On android, allow for other notification icon resource names than `ic_launcher`
 - Explore options of background execution for iOS (help needed, I don't have any Mac/iOS devices or experience with programming for them)
-
-If you experience any problems with this package, please [create an issue on Github](https://github.com/JulianAssmann/flutter_background/issues).
-Pull requests are also very welcome.
 
 ## Maintainer
 
 [Julian Aßmann](https://github.com/JulianAssmann)
+
+If you experience any problems with this package, please [create an issue on Github](https://github.com/JulianAssmann/flutter_background/issues).
+Pull requests are also very welcome.

--- a/android/src/main/kotlin/de/julianassmann/flutter_background/PermissionHandler.kt
+++ b/android/src/main/kotlin/de/julianassmann/flutter_background/PermissionHandler.kt
@@ -49,14 +49,12 @@ class PermissionHandler(private val context: Context,
             when {
                 powerManager.isIgnoringBatteryOptimizations(context.packageName) -> {
                     result.success(true)
-                    return
                 }
                 context.checkSelfPermission(Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS) == PackageManager.PERMISSION_DENIED -> {
                     result.error(
                             "flutter_background.PermissionHandler",
                             "The app does not have the REQUEST_IGNORE_BATTERY_OPTIMIZATIONS permission required to ask the user for whitelisting. See the documentation on how to setup this plugin properly.",
                             null)
-                    return
                 }
                 else -> {
                     addActivityResultListener(PermissionActivityResultListener(result::success, result::error))
@@ -76,16 +74,16 @@ class PermissionActivityResultListener(
 
     private var alreadyCalled: Boolean = false;
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
-        if (alreadyCalled || requestCode != PermissionHandler.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS) {
-            return false;
-        }
+        try {
+            if (alreadyCalled || requestCode != PermissionHandler.PERMISSION_CODE_IGNORE_BATTERY_OPTIMIZATIONS) {
+                return false
+            }
 
-        alreadyCalled = true;
+            alreadyCalled = true
 
-        if(resultCode == Activity.RESULT_OK) {
-            onSuccess(true)
-        } else {
-            onSuccess(false)
+            onSuccess(resultCode == Activity.RESULT_OK)
+        } catch (ex: Exception) {
+            onError("flutter_background.PermissionHandler", "Error while waiting for user to disable battery optimizations", ex.localizedMessage)
         }
 
         return true

--- a/example/lib/bloc/tcp_client_bloc/tcp_client_bloc.dart
+++ b/example/lib/bloc/tcp_client_bloc/tcp_client_bloc.dart
@@ -36,12 +36,21 @@ class TcpClientBloc extends Bloc<TcpClientEvent, TcpClientState> {
   Stream<TcpClientState> _mapConnectToState(Connect event) async* {
     yield state.copywith(connectionState: SocketConnectionState.Connecting);
 
-    final hasPermissions = await FlutterBackground.initialize(
-      androidConfig: FlutterBackgroundAndroidConfig(
-        notificationTitle: 'flutter_background example app',
-        notificationText: 'Background notification for keeping the example app running in the background'
-      )
-    );
+    var hasPermissions = await FlutterBackground.hasPermissions;
+    if (!hasPermissions) {
+      // TODO: Show warning to user or something
+      print('hasPermissions: $hasPermissions');
+    }
+    try {
+      hasPermissions = await FlutterBackground.initialize(
+        androidConfig: FlutterBackgroundAndroidConfig(
+          notificationTitle: 'flutter_background example app',
+          notificationText: 'Background notification for keeping the example app running in the background'
+        )
+      );
+    } catch (ex) {
+      print(ex);
+    }
     if (hasPermissions) {
       final backgroundExecution = await FlutterBackground.enableBackgroundExecution();
       if (backgroundExecution) {

--- a/example/lib/pages/home_page.dart
+++ b/example/lib/pages/home_page.dart
@@ -27,7 +27,7 @@ class _MainPageState extends State<MainPage> {
     _tcpBloc =  BlocProvider.of<TcpClientBloc>(context);
 
     _hostEditingController = TextEditingController(text: '10.0.2.2');
-    _portEditingController = TextEditingController(text: '8000');
+    _portEditingController = TextEditingController(text: '5555');
     _chatTextEditingController = TextEditingController(text: '');
 
     _chatTextEditingController.addListener(() {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -82,7 +82,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.2+1"
+    version: "0.1.4"
   flutter_bloc:
     dependency: "direct main"
     description:

--- a/lib/src/flutter_background.dart
+++ b/lib/src/flutter_background.dart
@@ -29,7 +29,7 @@ class FlutterBackground {
   /// Indicates whether or not the user has given the necessary permissions in order to run in the background.
   ///
   /// Returns true, if the user has granted the permission, otherwise false.
-  /// May throw a [PlatfromException].
+  /// May throw a [PlatformException].
   static Future<bool> get hasPermissions async {
     return await _channel.invokeMethod('hasPermissions') as bool;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_background
 description: A plugin to keep flutter apps running in the background by using foreground service, wake lock and disabling battery optimizations
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/JulianAssmann/flutter_background
 homepage: https://julianassmann.de/
 


### PR DESCRIPTION
* Fix bug where calling `FlutterBackground.initialize()` for the first time crashes the app
* Fix bug where calling `FlutterBackground.hasPermissions` for the first time crashes the app
* Fix some typos
* Address notification icon in the documentation
* Enhance error handling in example app

The bug was due to a call to `result.success()` when calling `FlutterBackground.initialize()` even if the app was still waiting for the user to ignore battery optimizations, allowing for subsequent calls to `FlutterBackground.enableBackgroundExecution()`, that failed because the battery optimizations were not granted at this time.