### PR TITLE
typo: Undefined name 'androidconfig' from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ final androidConfig = FlutterBackgroundAndroidConfig(
     notificationImportance: AndroidNotificationImportance.Default,
     notificationIcon: AndroidResource(name: 'background_icon', defType: 'drawable'), // Default is ic_launcher from folder mipmap
 );
-bool success = await FlutterBackground.initialize(androidConfig: androidconfig);
+bool success = await FlutterBackground.initialize(androidConfig: androidConfig);
 ```
 
 This ensures all permissions are granted and requests them if necessary. It also configures the


### PR DESCRIPTION
In the `README.md` there is this code block

```dart
final androidConfig = FlutterBackgroundAndroidConfig(
  notificationTitle: "Title of the notification",
  notificationText: "Text of the notification",
  notificationImportance: AndroidNotificationImportance.Default,
  notificationIcon: AndroidResource(
      name: 'background_icon', defType: 'drawable'), // Default is ic_launcher from folder mipmap
);
FlutterBackground.initialize(androidConfig: androidconfig);
```

But `androidConfig` is defined with a big `C`. So `FlutterBackground.initialize(androidConfig: androidconfig)` should use `androidConfig` instead of `androidconfig`