### PR TITLE
Handle null Intent in IsolateHolderService.kt onStartComment

### DIFF
--- a/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
+++ b/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
@@ -83,8 +83,8 @@ class IsolateHolderService : Service() {
         super.onCreate()
     }
 
-    override fun onStartCommand(intent: Intent, flags: Int, startId: Int) : Int {
-        if (intent.action == ACTION_SHUTDOWN) {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int) : Int {
+        if (intent?.action == ACTION_SHUTDOWN) {
             (getSystemService(Context.POWER_SERVICE) as PowerManager).run {
                 newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG).apply {
                     if (isHeld) {


### PR DESCRIPTION
This pull request contains a fix for #30 where we simply just make the Intent parameter of onStartCommand method nullable, and make the accessing of the intent variable null safe.