### PR TITLE
Remove invalid foreground service notification importance levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ In order to function correctly, this plugin needs a few permissions.
 `FlutterBackground.initialize(...)` will request permissions from the user if necessary.
 You can call initialize more than one time, so you can call `initalize()` every time before you call `enableBackgroundExecution()` (see below).
 
-In order to notify the user about upcoming permission requests by the system, you need to know, whether or not the app already has these permissions. You can find out by calling
+In order to notify the user about upcoming permission requests by the system, you need to know whether or not the app already has these permissions. You can find out by calling
 
 ```dart
 bool hasPermissions = await FlutterBackground.hasPermissions;
@@ -98,7 +98,7 @@ you can stop the background execution of the app. You must call `FlutterBackgrou
 To check whether background execution is currently enabled, use
 
 ```dart
-bool enabled = FlutterBackground.isBackgroundExecutionEnabled
+bool enabled = FlutterBackground.isBackgroundExecutionEnabled;
 ```
 
 ## Example

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip

--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example/lib/bloc/tcp_client_bloc/tcp_client_bloc.dart
+++ b/example/lib/bloc/tcp_client_bloc/tcp_client_bloc.dart
@@ -47,6 +47,7 @@ class TcpClientBloc extends Bloc<TcpClientEvent, TcpClientState> {
         notificationText:
             'Background notification for keeping the example app running in the background',
         notificationIcon: AndroidResource(name: 'background_icon'),
+        notificationImportance: AndroidNotificationImportance.Default,
       );
       // Demonstrate calling initialize twice in a row is possible without causing problems.
       hasPermissions =

--- a/example/lib/models/message.dart
+++ b/example/lib/models/message.dart
@@ -5,9 +5,6 @@ class Message {
   final String message;
   final MessageOrigin origin;
 
-  Message({
-    required this.timestamp,
-    required this.message,
-    required this.origin
-  });
+  Message(
+      {required this.timestamp, required this.message, required this.origin});
 }

--- a/lib/src/android_config.dart
+++ b/lib/src/android_config.dart
@@ -1,9 +1,12 @@
 /// Represents the importance of an android notification as described
 /// under https://developer.android.com/training/notify-user/channels#importance.
 enum AndroidNotificationImportance {
+  // Low and min importance levels apparantly are not supported, see
+  // https://github.com/JulianAssmann/flutter_background/issues/37 for more.
+
+  // Min,
+  // Low,
   Default,
-  Min,
-  Low,
   High,
   Max,
 }

--- a/lib/src/flutter_background.dart
+++ b/lib/src/flutter_background.dart
@@ -81,10 +81,13 @@ class FlutterBackground {
   static int _androidNotificationImportanceToInt(
       AndroidNotificationImportance importance) {
     switch (importance) {
-      case AndroidNotificationImportance.Low:
-        return -1;
-      case AndroidNotificationImportance.Min:
-        return -2;
+      // Low and min importance levels apparantly are not supported, see
+      // https://github.com/JulianAssmann/flutter_background/issues/37 for more.
+
+      // case AndroidNotificationImportance.Low:
+      //   return -1;
+      // case AndroidNotificationImportance.Min:
+      //   return -2;
       case AndroidNotificationImportance.High:
         return 1;
       case AndroidNotificationImportance.Max:


### PR DESCRIPTION
Fixes #37 
Only `PRIORITY_DEFAULT`, `PRIORITY_HIGH` and `PRIORITY_MAX` seem to be valid priority levels when creating the notification channel for a foreground service notification in Android, even though the [documentation](https://developer.android.com/guide/components/foreground-services) claims otherwise. Therefore this PR removes the other options from the package.