### PR TITLE
Caching custom configuration in shared preferences

### DIFF
--- a/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
+++ b/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
@@ -42,6 +42,7 @@ class IsolateHolderService : Service() {
 
     @SuppressLint("WakelockTimeout")
     override fun onCreate() {
+        FlutterBackgroundPlugin.loadNotificationConfiguration(applicationContext)
 
         val pm = getApplicationContext().getPackageManager()
         val notificationIntent  =


### PR DESCRIPTION
Saving notification configuration to shared preferences, preventing the notification from resetting to the default text after an app auto-restart