### PR TITLE
Add FLAG_IMMUTABLE for pending intents preventing a crash when targeting Android 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 1.0.2+2
+
+* Fix crash when targeting Android S+ due to a missing immutable flag for pending intents
+
 ## 1.0.2+1
 
 * Simplified example application by removing the use of the BLoC pattern
 
 ## 1.0.2
 
-* Remove foreground service notification importance levels that cause an error on Android.
+* Remove foreground service notification importance levels that cause an error on Android
 
 ## 1.0.1
 
@@ -23,7 +27,7 @@
 
 ## 0.1.5
 
-* Add `isBackgroundExecutionEnabled` property to enable checking the current background execution state.
+* Add `isBackgroundExecutionEnabled` property to enable checking the current background execution state
 
 ## 0.1.4
 

--- a/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
+++ b/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
@@ -3,18 +3,14 @@ package de.julianassmann.flutter_background
 import android.annotation.SuppressLint
 import android.app.NotificationChannel
 import android.app.NotificationManager
-import android.app.PendingIntent;
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager;
 import android.os.Build
 import android.os.IBinder
 import android.os.PowerManager
 import androidx.core.app.NotificationCompat
-import android.util.Log
-import androidx.core.app.NotificationManagerCompat
-import io.flutter.embedding.engine.FlutterEngine
 
 class IsolateHolderService : Service() {
     companion object {
@@ -37,19 +33,25 @@ class IsolateHolderService : Service() {
     }
 
     override fun onBind(intent: Intent) : IBinder? {
-        return null;
+        return null
     }
 
     @SuppressLint("WakelockTimeout")
     override fun onCreate() {
 
-        val pm = getApplicationContext().getPackageManager()
+        val pm = applicationContext.packageManager
         val notificationIntent  =
-            pm.getLaunchIntentForPackage(getApplicationContext().getPackageName())
+            pm.getLaunchIntentForPackage(applicationContext.packageName)
+
+        // See https://developer.android.com/guide/components/intents-filters#DeclareMutabilityPendingIntent
+        var flags = PendingIntent.FLAG_UPDATE_CURRENT
+        if (Build.VERSION.SDK_INT > 23) flags = flags or PendingIntent.FLAG_IMMUTABLE
+
         val pendingIntent  = PendingIntent.getActivity(
             this, 0,
-            notificationIntent, 0
+            notificationIntent, flags
         )
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
                     CHANNEL_ID,
@@ -95,11 +97,11 @@ class IsolateHolderService : Service() {
             stopForeground(true)
             stopSelf()
         }
-        return START_STICKY;
+        return START_STICKY
     } 
 
     override fun onTaskRemoved(rootIntent: Intent) {
-        super.onTaskRemoved(rootIntent);
-        stopSelf();
+        super.onTaskRemoved(rootIntent)
+        stopSelf()
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_background
 description: A plugin to keep flutter apps running in the background by using foreground service, wake lock and disabling battery optimizations
-version: 1.0.2+1
+version: 1.0.2+2
 repository: https://github.com/JulianAssmann/flutter_background
 homepage: https://julianassmann.de/
 


### PR DESCRIPTION
Adds `FLAG_IMMUTABLE` for pending intents preventing a crash when targeting Android 12. See https://developer.android.com/guide/components/intents-filters#DeclareMutabilityPendingIntent for more.

Fixes #44 