### PR TITLE
Declare the holder service in AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="de.julianassmann.flutter_background">
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+
+    <application>
+        <service android:name=".IsolateHolderService">
+            <!--android:exported="false"
+            android:foregroundServiceType="connectedDevice|dataSync" -->
+        </service>
+    </application>
 </manifest>


### PR DESCRIPTION
Without it the IsolateHolderService won't start. See issue https://github.com/JulianAssmann/flutter_background/issues/69

Perhaps the reasoning behind [this change](https://github.com/JulianAssmann/flutter_background/commit/fcce0d57525802b6f720dee0a080a10a0feaca4b#diff-93083d0574bec8be4b25f798b65dd82a612412c23a79dc9bdfdfb4a6b7ab37a3L5-L13) was that users should declare the service in the application's AndroidManifest.xml, but this has not been communicated in [the README](https://github.com/JulianAssmann/flutter_background/blob/d1ca4140ce43ad4e85545eb474ed70d8574996f3/README.md?plain=1#L21-L33).

Or would you prefer that in this PR, instead of modifying the AndroidManifest.xml of this plugin, change the README to instruct the user to add the `service` section to their own AndroidManifest.xml?