### PR TITLE
Add Service Type for IsolateHolderService

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,9 +1,11 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="de.julianassmann.flutter_background">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="de.julianassmann.flutter_background">
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
   <application>
-  <service android:name="de.julianassmann.flutter_background.IsolateHolderService" android:exported="true" /> 
+  <service
+      android:name="de.julianassmann.flutter_background.IsolateHolderService"
+      android:foregroundServiceType="specialUse"
+      android:exported="true" />
   </application>
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
   <application>
   <service
       android:name="de.julianassmann.flutter_background.IsolateHolderService"

--- a/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
+++ b/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.IBinder
@@ -125,7 +126,16 @@ class IsolateHolderService : Service() {
             }
         }
 
-        startForeground(1, notification)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(
+                1,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE);
+        } else {
+            startForeground(
+                1,
+                notification);
+        }
     }
 
     override fun onTaskRemoved(rootIntent: Intent) {


### PR DESCRIPTION
Starting in Android 14, all foreground service must list at least one foreground service type for each service.

Without listing a service type, the system will raise `SecurityException`.

https://developer.android.com/about/versions/14/behavior-changes-14#fgs-types