### PR TITLE
Set foreground service type

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,22 @@ Add the following permissions to the `AndroidManifest.xml`:
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.julianassmann.flutter_background_example">
 
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <!-- Adapt to the foreground service type desired -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application>
-    ...
+        ...
+
+        <service
+            android:name="de.julianassmann.flutter_background.IsolateHolderService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync|specialUse|..." />
     </application>
 </manifest>
 ```
+
+See [the Android docs](https://developer.android.com/develop/background-work/services/fg-service-types)
+for more information on foreground service types.
 
 ### iOS
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,7 +3,4 @@
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
-  <application>
-  <service android:name="de.julianassmann.flutter_background.IsolateHolderService" android:exported="true" /> 
-  </application>
 </manifest>

--- a/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
+++ b/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.IBinder
@@ -125,7 +126,11 @@ class IsolateHolderService : Service() {
             }
         }
 
-        startForeground(1, notification)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(1, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST);
+        } else {
+            startForeground(1, notification)
+        }
     }
 
     override fun onTaskRemoved(rootIntent: Intent) {


### PR DESCRIPTION
Same goal as https://github.com/JulianAssmann/flutter_background/pull/83 (Android 14 compat), with these differences:

- Use `FOREGROUND_SERVICE_TYPE_MANIFEST` instead of any specific hardcoded value.
- Leave it up to users to declare the `<service>` with the proper `foregroundServiceType`.