### PR TITLE
Remove references to deprecated v1 Android embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.0
+
+* **Breaking**: Support for Android 14 and above, as all foreground service must list at least one foreground service type for each service. This requires users to define
+* Remove references to deprecated v1 Android embedding as it will be removed in Flutter 3.26 (see the [Flutter 3.22 release notes](https://medium.com/flutter/whats-new-in-flutter-3-22-fbde6c164fe3) and the [migration guide](https://docs.flutter.dev/release/breaking-changes/plugin-api-migration))
+* Move Gradle from imperative apply to declarative plugins (see [here](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply) for more information)
+* Move the example project to a new version of the [flutter_local_notifications](https://pub.dev/packages/flutter_local_notifications) to get the notifications running again in the latest versions of Android
+
 ## 1.2.0
 
 * Add option to hide notification badge

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [!["Buy Me A Coffee"](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/julianassmann)
 
-
 A plugin to keep flutter apps running in the background. Currently only works with Android.
 
 It achieves this functionality by running an [Android foreground service](https://developer.android.com/guide/components/foreground-services) in combination with a [partial wake lock](https://developer.android.com/training/scheduling/wakelock#cpu) and [disabling battery optimizations](https://developer.android.com/training/monitoring-device-state/doze-standby#support_for_other_use_cases) in order to keep the flutter isolate running.
@@ -22,12 +21,19 @@ Add the following permissions to the `AndroidManifest.xml`:
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="de.julianassmann.flutter_background_example">
 
-    <!-- Adapt to the foreground service type desired -->
+    <!-- General permissions for the flutter_background plugin -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
+    <!-- Adapt to the foreground service type(s) desired, these are just examples -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application>
         ...
 
+        <!-- Adapt to the foreground service type(s) desired, these are just examples -->
         <service
             android:name="de.julianassmann.flutter_background.IsolateHolderService"
             android:exported="false"

--- a/android/src/main/kotlin/de/julianassmann/flutter_background/FlutterBackgroundPlugin.kt
+++ b/android/src/main/kotlin/de/julianassmann/flutter_background/FlutterBackgroundPlugin.kt
@@ -15,7 +15,6 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 class FlutterBackgroundPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   private var methodChannel : MethodChannel? = null
@@ -24,12 +23,6 @@ class FlutterBackgroundPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   private var context: Context? = null
 
   companion object {
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-      val channel = MethodChannel(registrar.messenger(), "flutter_background")
-      channel.setMethodCallHandler(FlutterBackgroundPlugin())
-    }
-
     @JvmStatic
     val NOTIFICATION_TITLE_KEY = "android.notificationTitle"
     @JvmStatic

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -328,5 +328,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -17,14 +17,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
-  bloc:
-    dependency: transitive
-    description:
-      name: bloc
-      sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.1.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -65,14 +57,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.18.0"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.8"
   dbus:
     dependency: transitive
     description:
@@ -108,15 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
-  flutter_bloc:
-    dependency: "direct main"
-    description:
-      name: flutter_bloc
-      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.1.6"
+    version: "1.3.0"
   flutter_local_notifications:
     dependency: "direct main"
     description:
@@ -194,14 +170,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -226,14 +194,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
-  provider:
-    dependency: transitive
-    description:
-      name: provider
-      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.2"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,8 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cupertino_icons: ^1.0.2
-  flutter_bloc: ^8.0.1
   flutter_local_notifications: ^17.2.2
   bubble: ^1.2.1
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,5 +209,5 @@ packages:
     source: hosted
     version: "14.2.4"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -58,10 +58,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "4.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -95,10 +95,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: flutter_background
 description: A plugin to keep flutter apps running in the background.
-version: 1.2.0
+version: 1.3.0
 repository: https://github.com/JulianAssmann/flutter_background
 homepage: https://julianassmann.de/
 
 environment:
-  sdk: ">=2.17.6 <3.0.0"
-  flutter: ">=2.5.0"
+  sdk: ">=3.4.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,18 +5,18 @@ repository: https://github.com/JulianAssmann/flutter_background
 homepage: https://julianassmann.de/
 
 environment:
-  sdk: ">=3.4.0"
+  sdk: ">=3.4.0 <4.0.0"
   flutter: ">=3.16.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.0.2
+  plugin_platform_interface: ^2.1.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^4.0.0
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes #88.
This PR also marks a new release with version 1.3.0 of the plugin, now supporting Android 14 and above.