### PR TITLE
Use Flutter's preferred Android compileSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ group 'de.julianassmann.flutter_background'
 version '1.0-SNAPSHOT'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Avoid relying on an old Android SDK for compiling the package.

Flutter's preferred compileSdkVersion is higher than 34: https://github.com/flutter/flutter/blob/d93e2d4b82ba2cc1b730948a81f823d52374d5dc/packages/flutter_tools/lib/src/android/gradle_utils.dart#L52