### PR TITLE
Fix: WakeLock finalized while still held

### DIFF
--- a/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
+++ b/android/src/main/kotlin/de/julianassmann/flutter_background/IsolateHolderService.kt
@@ -47,11 +47,12 @@ class IsolateHolderService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int) : Int {
-        if (intent?.action == ACTION_SHUTDOWN) {
-            cleanupService()
-            stopSelf()
-        } else if (intent?.action == ACTION_START) {
-            startService()
+        when (intent?.action) {
+            ACTION_SHUTDOWN -> {
+                cleanupService()
+                stopSelf()
+            }
+            else -> startService() // ACTION_START or null (OS sticky restart)
         }
         return START_STICKY
     }
@@ -112,6 +113,7 @@ class IsolateHolderService : Service() {
             .setPriority(FlutterBackgroundPlugin.notificationImportance)
             .build()
 
+        wakeLock?.apply { if (isHeld) release() }
         (getSystemService(Context.POWER_SERVICE) as PowerManager).run {
             wakeLock = newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG).apply {
                 setReferenceCounted(false)
@@ -119,6 +121,9 @@ class IsolateHolderService : Service() {
             }
         }
 
+        if (FlutterBackgroundPlugin.enableWifiLock) {
+            wifiLock?.apply { if (isHeld) release() }
+        }
         (applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager).run {
             wifiLock = createWifiLock(WifiManager.WIFI_MODE_FULL, WIFILOCK_TAG).apply {
                 setReferenceCounted(false)


### PR DESCRIPTION
Fixes #35

## Summary

- Before re-acquiring the WakeLock (and WifiLock) in `startService()`, any existing held lock is now released first. This prevents orphaned lock objects from being GC'd while still held, which caused the `WakeLock finalized while still held` logcat error.
- `onStartCommand` now handles `null` intents (delivered by Android on `START_STICKY` service restarts after a system kill) by calling `startService()`, ensuring locks are properly re-acquired after the OS kills and restarts the service.

## Test plan

- [ ] Run on a physical Android device (emulators don't reliably surface WakeLock issues)
- [ ] Call `enableBackgroundExecution()` twice without disabling — verify no `WakeLock finalized while still held` in logcat
- [ ] Call `enableBackgroundExecution()` then `disableBackgroundExecution()` — verify no error appears a few seconds later
- [ ] Force-kill the app process with `adb shell am kill <package>` while service is running — verify service restarts and continues functioning